### PR TITLE
fixed activeUser not re-updating for post section

### DIFF
--- a/src/scripts/posts/PostList.js
+++ b/src/scripts/posts/PostList.js
@@ -13,7 +13,8 @@ const eventHub = document.querySelector(".container")
 
 // When changes to posts occur, re-render notes
 eventHub.addEventListener("postStateChanged", e => {
-    listPosts();
+    const activeUser = parseInt(sessionStorage.getItem("activeUser"))
+    listPosts(activeUser);
 })
 
 // Listen for button clicks in Posts section


### PR DESCRIPTION
# Description
Fixed issue where activeUser was only being pulled into the Posts section on the initial login and not whenever a post change event occurred.
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
Login or register, then create, edit, and delete multiple posts. You should always stay as the active user.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
