### PR TITLE
Post Zip as Int

### DIFF
--- a/src/scripts/auth/RegisterForm.js
+++ b/src/scripts/auth/RegisterForm.js
@@ -43,7 +43,7 @@ eventHub.addEventListener("click", (e) => {
                 body: JSON.stringify({
                   username: username,
                   email: email,
-                  zipcode: zipcode,
+                  zipcode: parseInt(zipcode),
                 }),
               })
                 .then((response) => response.json())


### PR DESCRIPTION
# Description
Minor bug fix. However, any previously stored users will have zips saved as strings. If you want to keep them, you will need to manually change your zip codes to integers.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
zip code was being stored as a string; now it's an integer
# Testing Instructions
Register as a new user and check stored user's zip code--it should be an integer rather than a string.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
